### PR TITLE
Added oc3-sanitize functionality

### DIFF
--- a/openshift/migration/oc3-export/.env.template
+++ b/openshift/migration/oc3-export/.env.template
@@ -6,3 +6,5 @@ OC4_LICENSEPLATE=<place licenseplate here.  eg: abc123 {not the -dev or -test, e
 OC4_ENVIRONMENT=<place list of environments here  eg: dev,tools>
 PROJECT=<place project name here - arbitrary entry>
 DEBUG=0
+CLOBBER=<do you want to overwrite previously exported manifest files 0:1> eg: 1
+SANITIZE<do you want to generate sanitized versions of each manifest 0:1> eg: 1

--- a/openshift/migration/oc3-export/README.md
+++ b/openshift/migration/oc3-export/README.md
@@ -19,6 +19,20 @@ ENVIRONMENT: dev,test,prod,tools
 PROJECT: MyProject
 - This is an arbitrary project name used for helping keep the folder structure organized.
 
+DEBUG: 0
+- Turn on debugging output.
+- Boolean, default 0
+
+CLOBBER: 0
+ - Toggle the overwrite (aka clobbering) of existing files.
+ - Boolean, default 0
+ - Will overwrite omnimanifest regardless of setting.
+
+SANITIZE: 0
+ - create a sanitized version of the object manifest files.
+ - strips out unnecessary elements to allow the manifest file to be used for future importing.
+ - Boolean, default 0
+
 # Run
 
 To run the project simply run the docker-compose
@@ -28,3 +42,6 @@ For convince the container just mounts the local folder rather than copying the 
 # Output
 
 The output will display discrepancies between the omnimanifest and the category files.
+
+# Known Issues
+- on a Windows system we discovered that the due to mounting the OS you have to explicitly share the folder within your docker server settings.

--- a/openshift/migration/oc3-export/_unused_oc3-sanitize.py
+++ b/openshift/migration/oc3-export/_unused_oc3-sanitize.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+####
+#   NOT CURRENTLY USED
+#   - this method changes the yaml content formating which is less readable and not optimal
+#     so I've obsoleted this script in favour of using sed in bash.
+#     keeing this around for reference for now.
+#   Used to compare the omnimanifest, that was exported from openshift 3, to the catagory manifests
+#   to determine if something may have gone wrong.  This is not a definitive test as we're only
+#   comparing one way.
+#
+#   ** CAUTION: This exports the oc secrets - DO NOT COMMIT SECRETS TO GIT!
+#
+####
+
+import yaml
+from nested_lookup import get_occurrence_of_key, nested_delete, nested_lookup
+from pprint import pprint
+import os
+import sys
+
+
+directory = sys.argv[1]
+location=directory+"/sanitized/"
+if not os.path.exists(location):
+    os.mkdir(location)
+
+groupedManifestList = []
+for filename in os.listdir(directory):
+    if filename!="all_objects.yaml" and filename!="sanitized":
+        workingfile = open(os.path.join(directory, filename))
+        with workingfile as file:
+            dataDict = yaml.safe_load(file)
+
+        print("Sanitizing "+filename)
+
+        dataDictionatry = {key: value for key, value in dataDict.items() if value is not None}
+
+        #print(dataDictionatry)
+
+        # results = nested_delete(dataDict, "resourceVersion", in_place=True)
+        # results = nested_delete(dataDict, "selfLink", in_place=True)
+        # results = nested_delete(dataDict, "creationTimestamp", in_place=True)
+        # results = nested_delete(dataDict, "uid", in_place=True)
+        # results = nested_delete(dataDict, "namespace", in_place=True)
+
+        # results = nested_delete(dataDict, "resourceVersion", in_place=True)
+        # results = nested_delete(dataDict, "selfLink", in_place=True)
+        # results = nested_delete(dataDict, "namespace", in_place=True)
+        
+        # results = nested_delete(dataDict, "status", in_place=True)
+        # results = nested_delete(dataDict, "items", in_place=True)
+
+        #results = nested_delete(dataDict, "annotations", in_place=True)
+
+
+        #result = nested_lookup('resourceVersion', dataDict)
+
+        #print(dataDict)
+        # print(type(result))
+
+
+        print("Writing to file: "+filename)
+        with open(location+"/"+filename, 'w') as file:
+            documents = yaml.dump(results, file)
+
+exit()

--- a/openshift/migration/oc3-export/oc3-compare.py
+++ b/openshift/migration/oc3-export/oc3-compare.py
@@ -3,8 +3,8 @@
 ####
 #
 #   Used to compare the omnimanifest, that was exported from openshift 3, to the catagory manifests
-#   to determine if something may have gone wrong.  This is not a definitive test as we're only
-#   comparing one way.
+#   to determine if something may have gone wrong.
+#   This is not a definitive test as we're only comparing one way.
 #
 #   ** CAUTION: This exports the oc secrets - DO NOT COMMIT SECRETS TO GIT!
 #
@@ -49,7 +49,7 @@ for filename in os.listdir(directory):
 
 
 # for each item in the omniManifestList we need to see if we can find that item in the groupedManifestList
-pprint("Searching through omnimanifest on project "+directory)
+pprint("Comparing omnimanifest to discreet objects in: "+directory)
 for itemList in omniManifestList:
 
     #pprint(itemList)

--- a/openshift/migration/oc3-export/requirements.txt
+++ b/openshift/migration/oc3-export/requirements.txt
@@ -1,1 +1,2 @@
 PyYaml
+#nested-lookup


### PR DESCRIPTION
I've added sanitize functionality that takes the exported manifest files and strips out unneeded elements and removed manifests that are basically empty.

I've also enhanced/tweaked the export function with some cleanup and added the clobber param to allow/prevent clobbering the previously exported manifest files.